### PR TITLE
Pass event loop explicitly

### DIFF
--- a/aioxmlrpc/tests/test_client.py
+++ b/aioxmlrpc/tests/test_client.py
@@ -79,7 +79,7 @@ class ServerProxyTestCase(TestCase):
 
     def test_xmlrpc_ok(self):
         from aioxmlrpc.client import ServerProxy
-        client = ServerProxy('http://localhost/test_xmlrpc_ok')
+        client = ServerProxy('http://localhost/test_xmlrpc_ok', loop=self.loop)
         response = self.loop.run_until_complete(
             client.name.space.proxfyiedcall()
             )
@@ -87,7 +87,8 @@ class ServerProxyTestCase(TestCase):
 
     def test_xmlrpc_fault(self):
         from aioxmlrpc.client import ServerProxy, Fault
-        client = ServerProxy('http://localhost/test_xmlrpc_fault')
+        client = ServerProxy('http://localhost/test_xmlrpc_fault',
+                             loop=self.loop)
         self.assertRaises(Fault,
                           self.loop.run_until_complete,
                           client.name.space.proxfyiedcall()
@@ -95,7 +96,7 @@ class ServerProxyTestCase(TestCase):
 
     def test_http_500(self):
         from aioxmlrpc.client import ServerProxy, ProtocolError
-        client = ServerProxy('http://localhost/test_http_500')
+        client = ServerProxy('http://localhost/test_http_500', loop=self.loop)
         self.assertRaises(ProtocolError,
                           self.loop.run_until_complete,
                           client.name.space.proxfyiedcall()

--- a/aioxmlrpc/tests/test_client.py
+++ b/aioxmlrpc/tests/test_client.py
@@ -84,6 +84,7 @@ class ServerProxyTestCase(TestCase):
             client.name.space.proxfyiedcall()
             )
         self.assertEqual(response, 1)
+        self.assertIs(self.loop, client._loop)
 
     def test_xmlrpc_fault(self):
         from aioxmlrpc.client import ServerProxy, Fault
@@ -101,3 +102,14 @@ class ServerProxyTestCase(TestCase):
                           self.loop.run_until_complete,
                           client.name.space.proxfyiedcall()
                           )
+
+    def test_xmlrpc_ok_gloabal_loop(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        from aioxmlrpc.client import ServerProxy
+        client = ServerProxy('http://localhost/test_xmlrpc_ok')
+        response = self.loop.run_until_complete(
+            client.name.space.proxfyiedcall()
+            )
+        self.assertIs(loop, client._loop)
+        self.assertEqual(response, 1)


### PR DESCRIPTION
Hi,
I have added two improvements:
1) event loop now passed explicitly, so library will play nice with other asyncio projects.
2) aiohttp.TCPConnector added to keep connection alive and save on reconnections.
