### PR TITLE
Fixes issue #3: Error while using newer aiohttp version

### DIFF
--- a/aioxmlrpc/client.py
+++ b/aioxmlrpc/client.py
@@ -69,7 +69,7 @@ class AioTransport(xmlrpc.Transport):
             response = yield from aiohttp.request(
                 'POST', url, headers=headers, data=request_body,
                 connector=self._connector, loop=self._loop)
-            body = yield from response.read_and_close()
+            body = yield from response.text()
             if response.status != 200:
                 raise ProtocolError(url, response.status,
                                     body, response.headers)

--- a/aioxmlrpc/tests/test_client.py
+++ b/aioxmlrpc/tests/test_client.py
@@ -55,7 +55,7 @@ def dummy_response(method, url, **kwargs):
             self.headers = {}
 
         @asyncio.coroutine
-        def read_and_close(self):
+        def text(self):
             return self.body
 
     return Response()


### PR DESCRIPTION
The aiohttp method ClientResponse.read_and_close() is gone as of december 2015.
So aioxmlrpc will raise and error when using it, this commit replace it by a
call to ClientResponse.text()
