### PR TITLE
Fix: transport must be closed when work is finished

### DIFF
--- a/aioxmlrpc/client.py
+++ b/aioxmlrpc/client.py
@@ -98,6 +98,9 @@ class AioTransport(xmlrpc.Transport):
         scheme = 'https' if self.use_https else 'http'
         return '%s://%s%s' % (scheme, host, handler)
 
+    def close(self):
+    	self._connector.close()
+
 
 class ServerProxy(xmlrpc.ServerProxy):
     """
@@ -131,6 +134,9 @@ class ServerProxy(xmlrpc.ServerProxy):
             response = response[0]
 
         return response
+
+    def close(self):
+    	self.__transport.close()
 
     def __getattr__(self, name):
         return _Method(self.__request, name)

--- a/aioxmlrpc/tests/test_client.py
+++ b/aioxmlrpc/tests/test_client.py
@@ -113,3 +113,18 @@ class ServerProxyTestCase(TestCase):
             )
         self.assertIs(loop, client._loop)
         self.assertEqual(response, 1)
+
+    def test_close_transport(self):
+      from aioxmlrpc.client import ServerProxy, AioTransport
+
+      transp = AioTransport(use_https=False, loop=self.loop)
+      transp._connector.close = mock.Mock()
+      client = ServerProxy('http://localhost/test_xmlrpc_ok',
+                           loop=self.loop, transport=transp)
+      response = self.loop.run_until_complete(
+          client.name.space.proxfyiedcall()
+      )
+      client.close()
+      self.assertEqual(response, 1)
+      self.assertIs(self.loop, client._loop)
+      self.assertTrue(transp._connector.close.called)


### PR DESCRIPTION
asyncio generate this warning:
`Unclosed connector
connections: ['[(<TCPTransport closed=True reading=False 0x1e5c178>, <aiohttp.parsers.StreamProtocol object at 0x7f9af8173e80>, 7585.671)]']
connector: <aiohttp.connector.TCPConnector object at 0x7f9b02505be0>`
