### PR TITLE
Fix httpx._types.VerifyTypes type hint

### DIFF
--- a/src/aioxmlrpc/client.py
+++ b/src/aioxmlrpc/client.py
@@ -8,11 +8,13 @@ work with asyncio.
 
 import asyncio
 import logging
+import ssl
 from typing import (
     Any,
     Awaitable,
     Callable,
     Optional,
+    Union,
     cast,
 )
 from xmlrpc import client as xmlrpc
@@ -153,7 +155,7 @@ class ServerProxy(xmlrpc.ServerProxy):
         auth: Optional[httpx._types.AuthTypes] = None,
         *,
         headers: Optional[dict[str, Any]] = None,
-        context: Optional[httpx._types.VerifyTypes] = None,
+        context: Optional[Union[bool, ssl.SSLContext]] = None,
         timeout: httpx._types.TimeoutTypes = 5.0,
         session: Optional[httpx.AsyncClient] = None,
     ) -> None:


### PR DESCRIPTION
httpx removes `VerifyTypes` in 0.28.0 (https://github.com/encode/httpx/commit/8e36f2bc685dfbe43cd7503bc1c422a6ed6e05a5)

Raises error:
```python
aioxmlrpc/client.py:156: in ServerProxy
    context: Optional[httpx._types.VerifyTypes] = None,
E   AttributeError: module 'httpx._types' has no attribute 'VerifyTypes'
```