### PR TITLE
Use content= instead of data= for httpx post

### DIFF
--- a/src/aioxmlrpc/client.py
+++ b/src/aioxmlrpc/client.py
@@ -76,7 +76,7 @@ class AioTransport(xmlrpc.Transport):
         self,
         host: str,
         handler: str,
-        request_body: dict[str, Any],
+        request_body: bytes,
         verbose: bool = False,
     ) -> RPCResult:
         """
@@ -88,7 +88,7 @@ class AioTransport(xmlrpc.Transport):
         try:
             response = await self._session.post(
                 url,
-                data=request_body,
+                content=request_body,
                 auth=self.auth,
                 timeout=self.timeout,
             )


### PR DESCRIPTION
This gets rid of httpx warning
`"Use 'content=<...>' to upload raw bytes/text content.`